### PR TITLE
Allow quoted wildcards in -f/--files.

### DIFF
--- a/src/concuerror.erl
+++ b/src/concuerror.erl
@@ -503,7 +503,7 @@ help() ->
      "  -t|--target module      Run eunit tests for this module\n"
      "  -t|--target module function [args]\n"
      "                          Specify the function to execute\n"
-     "  -f|--files  modules     Specify the files (modules) to instrument\n"
+     "  -f|--files  modules     Specify the files (modules) to instrument (quoted wildcards allowed)\n"
      "  -pa         Dir         Add Dir to the beginning of the code path\n"
      "  -pz         Dir         Add Dir to the end of the code path\n"
      "  -o|--output file        Specify the output file (default results.txt)\n"
@@ -566,8 +566,10 @@ analyzeAux(Options) ->
                         Msg2 = "no input files specified",
                         {'error', 'arguments', Msg2};
                     {files, Files} ->
+                        %% Retrieve file paths
+                        Files1 = concuerror_util:wildcards_to_filenames(Files),
                         %% Start the analysis
-                        concuerror_sched:analyze(Target, Files, Options)
+                        concuerror_sched:analyze(Target, Files1, Options)
                 end
         end,
     %% Return result

--- a/src/concuerror_gui.erl
+++ b/src/concuerror_gui.erl
@@ -868,7 +868,8 @@ loadPrefs(Options) ->
     case lists:keyfind('files', 1, Options) of
         false -> continue;
         {'files', Files} ->
-            AbsFiles = [filename:absname(F) || F <- Files],
+            Files1 = concuerror_util:wildcards_to_filenames(Files),
+            AbsFiles = [filename:absname(F) || F <- Files1],
             ErlFiles = [F || F <- AbsFiles, concuerror_util:is_erl_source(F)],
             addListItems(?MODULE_LIST, ErlFiles)
     end,

--- a/src/concuerror_util.erl
+++ b/src/concuerror_util.erl
@@ -16,7 +16,8 @@
 -export([doc/1, test/0, flat_format/2, flush_mailbox/0, get_module_name/1,
          is_erl_source/1, funs/1, funs/2, funLine/3, pmap/2, wait_messages/1,
          timer_init/0, timer_start/1, timer/1, timer_stop/1, timer_destroy/0,
-         init_state/0, progress_bar/2, to_elapsed_time/1, to_elapsed_time/2]).
+         init_state/0, progress_bar/2, to_elapsed_time/1, to_elapsed_time/2,
+         wildcards_to_filenames/1]).
 
 -export_type([progress/0]).
 
@@ -312,3 +313,9 @@ traceLoop(Pid, MsgQueueLen, I) ->
         false ->
             receive after 2 -> traceLoop(Pid, MsgQueueLen, I-1) end
     end.
+
+%% -------------------------------------------------------------------
+%% Convert a list of strings with path wildcards to a list of strings with paths
+-spec wildcards_to_filenames([string()]) -> [string()].
+wildcards_to_filenames(Ws) ->
+    lists:flatmap(fun filelib:wildcard/1, Ws).


### PR DESCRIPTION
I propose to allow wildcards with the `-f` parameter. This change allows the following call to specify the modules:

```
./concuerror --gui -f resources/tdd/reg_server\*.erl -t reg_server_test
```
