### PR TITLE
Compilation on R17

### DIFF
--- a/src/concuerror_rep.erl
+++ b/src/concuerror_rep.erl
@@ -311,7 +311,7 @@ find_my_links() ->
     find_my_links_or_monitors(links).
 
 find_my_monitored() ->
-    find_my_links_or_monitors(monitored_by).    
+    find_my_links_or_monitors(monitored_by).
 
 find_my_links_or_monitors(Type) ->
     PPid = self(),
@@ -423,7 +423,7 @@ rep_after_notify() ->
 %%
 %% Called first thing after a message has been received, to inform the scheduler
 %% about the message received and the sender.
--spec rep_receive_notify(pid(), dict(), term()) -> 'ok'.
+-spec rep_receive_notify(pid(), dict:dict(), term()) -> 'ok'.
 rep_receive_notify(From, CV, Msg) ->
     check_unknown_process(),
     concuerror_sched:notify('receive', {From, CV, Msg}, prev),
@@ -536,7 +536,7 @@ spawn_fun_wrapper(Fun) ->
             exit(Normal);
         Class:Type ->
             concuerror_sched:notify(error,[Class,Type,erlang:get_stacktrace()])
-    end.                    
+    end.
 
 find_my_info() ->
     MyEts = find_my_ets_tables(),

--- a/src/concuerror_sched.erl
+++ b/src/concuerror_sched.erl
@@ -183,7 +183,7 @@ do_analysis(Target, PreBound, Dpor, Options) ->
 -type instr()      :: term().
 -type transition() :: {concuerror_lid:lid(), instr(), list()}.
 -type lid_trace()  :: [{concuerror_lid:lid(), transition(), lid_trace()}].
--type clock_map()  :: dict(). %% dict(concuerror_lid:lid(), clock_vector()).
+-type clock_map()  :: dict:dict(). %% dict(concuerror_lid:lid(), clock_vector()).
 %% -type clock_vector() :: orddict(). %% dict(concuerror_lid:lid(), s_i()).
 
 -record(trace_state, {
@@ -196,7 +196,7 @@ do_analysis(Target, PreBound, Dpor, Options) ->
           backtrack = []                :: lid_trace(),
           done      = ordsets:new()     :: ordsets:ordset(concuerror_lid:lid()),
           sleep_set = ordsets:new()     :: ordsets:ordset(concuerror_lid:lid()),
-          nexts     = dict:new()        :: dict(), % dict(lid(), instr()),
+          nexts     = dict:new()        :: dict:dict(), % dict(lid(), instr()),
           clock_map = empty_clock_map() :: clock_map(),
           preemptions = 0               :: non_neg_integer(),
           race_checked = false          :: boolean()

--- a/src/concuerror_state.erl
+++ b/src/concuerror_state.erl
@@ -27,7 +27,7 @@
 -define(TERM_TO_BIN(X), term_to_binary(X, ?OPT_T2B)).
 -else.
 -type state() :: {{concuerror_lid:lid(),pos_integer()} | 'undefined',
-                  queue(),
+                  queue:queue(),
                   {concuerror_lid:lid(),pos_integer()} | 'undefined'}.
 -define(BIN_TO_TERM(X), X).
 -define(TERM_TO_BIN(X), X).


### PR DESCRIPTION
It is a breaking change, that doesn't compile on R15, R16 erlangs.

If there a convenience way for founding an erlang version and manipulating throw ifdefine preprocessor commands, please give me hint(or link to the documentation or example).
